### PR TITLE
 sprint2 capture image and detect smile face

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,6 @@ plugins {
     alias(libs.plugins.ksp.kotlin.symbol) apply false
     alias(libs.plugins.dagger.hilt) apply false
     alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.navigation.args) apply false
+
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,8 @@ activity = "1.10.0"
 constraintlayout = "2.2.0"
 sdpAndroid = "1.1.0"
 sspAndroid = "1.1.0"
+nav_version = "2.8.7"
+
 
 
 [libraries]
@@ -59,3 +61,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 dagger_hilt = {id = "com.google.dagger.hilt.android", version.ref = "dagger_hilt_plugin"}
 ksp-kotlin-symbol = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+navigation-args = { id = "androidx.navigation.safeargs.kotlin", version.ref = "nav_version" }

--- a/registration/build.gradle.kts
+++ b/registration/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp.kotlin.symbol)
     alias(libs.plugins.dagger.hilt)
+    alias(libs.plugins.navigation.args)
     id("kotlin-parcelize")
     id("maven-publish")
 }

--- a/registration/src/main/AndroidManifest.xml
+++ b/registration/src/main/AndroidManifest.xml
@@ -2,12 +2,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
     <application tools:targetApi="31"
         >
         <activity
             android:name="com.valify.registration.presentation.HostActivity"
             android:exported="true"
-            android:launchMode="singleInstance"
             android:theme="@style/Theme.RegistrationSDK" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/registration/src/main/java/com/valify/registration/data/datasources/local/AppDatabase.kt
+++ b/registration/src/main/java/com/valify/registration/data/datasources/local/AppDatabase.kt
@@ -2,11 +2,14 @@ package com.valify.registration.data.datasources.local
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import com.valify.registration.data.datasources.local.dao.ImageDao
 import com.valify.registration.data.datasources.local.dao.UserDao
+import com.valify.registration.data.datasources.local.entity.ImageEntity
 import com.valify.registration.data.datasources.local.entity.UserEntity
 
 
-@Database(entities = [UserEntity::class], version = 1, exportSchema = false)
+@Database(entities = [UserEntity::class, ImageEntity::class], version = 1, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
+    abstract fun imageDao(): ImageDao
 }

--- a/registration/src/main/java/com/valify/registration/data/datasources/local/dao/ImageDao.kt
+++ b/registration/src/main/java/com/valify/registration/data/datasources/local/dao/ImageDao.kt
@@ -1,0 +1,12 @@
+package com.valify.registration.data.datasources.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import com.valify.registration.data.datasources.local.entity.ImageEntity
+
+@Dao
+interface ImageDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertImage(image: ImageEntity): Long
+}

--- a/registration/src/main/java/com/valify/registration/data/datasources/local/entity/ImageEntity.kt
+++ b/registration/src/main/java/com/valify/registration/data/datasources/local/entity/ImageEntity.kt
@@ -1,0 +1,11 @@
+package com.valify.registration.data.datasources.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "captured_images")
+data class ImageEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+    val imageData: String,
+)

--- a/registration/src/main/java/com/valify/registration/data/di/DatabaseModule.kt
+++ b/registration/src/main/java/com/valify/registration/data/di/DatabaseModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.room.Room
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import com.valify.registration.data.datasources.local.AppDatabase
+import com.valify.registration.data.datasources.local.dao.ImageDao
 import com.valify.registration.data.datasources.local.dao.UserDao
 import com.valify.registration.data.utils.generateSecretKey
 import dagger.Module
@@ -30,5 +31,8 @@ object DatabaseModule {
 
     @Provides
     fun provideUserDao(database: AppDatabase): UserDao = database.userDao()
+
+    @Provides
+    fun provideImageDao(database: AppDatabase): ImageDao = database.imageDao()
 
 }

--- a/registration/src/main/java/com/valify/registration/data/di/RepositoryModule.kt
+++ b/registration/src/main/java/com/valify/registration/data/di/RepositoryModule.kt
@@ -1,7 +1,10 @@
 package com.valify.registration.data.di
 
+import com.valify.registration.data.datasources.local.dao.ImageDao
 import com.valify.registration.data.datasources.local.dao.UserDao
+import com.valify.registration.data.repository.ImageRepositoryImpl
 import com.valify.registration.data.repository.UserRepositoryImpl
+import com.valify.registration.domain.repository.ImageRepository
 import com.valify.registration.domain.repository.UserRepository
 import dagger.Module
 import dagger.Provides
@@ -18,6 +21,14 @@ object RepositoryModule {
         userDao: UserDao,
     ): UserRepository {
         return UserRepositoryImpl(userDao)
+    }
+
+    @Provides
+    @Singleton
+    fun provideImageRepository(
+        imageDao: ImageDao,
+    ): ImageRepository {
+        return ImageRepositoryImpl(imageDao)
     }
 
 }

--- a/registration/src/main/java/com/valify/registration/data/repository/ImageRepositoryImpl.kt
+++ b/registration/src/main/java/com/valify/registration/data/repository/ImageRepositoryImpl.kt
@@ -1,0 +1,30 @@
+package com.valify.registration.data.repository
+
+import android.database.sqlite.SQLiteException
+import com.valify.registration.data.datasources.local.dao.ImageDao
+import com.valify.registration.data.datasources.local.entity.ImageEntity
+import com.valify.registration.domain.repository.ImageRepository
+import com.valify.registration.domain.utils.AppError
+import com.valify.registration.domain.utils.ResultSource
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class ImageRepositoryImpl @Inject constructor(
+    private val imageDao: ImageDao,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ImageRepository {
+    override suspend fun saveCapturedImage(image: String): ResultSource<Boolean> = withContext(dispatcher) {
+        kotlin.runCatching {
+            imageDao.insertImage(ImageEntity(imageData = image))
+            ResultSource.Success(true)
+        }.getOrElse {
+            if (it is SQLiteException) {
+                ResultSource.Error(AppError.DatabaseError)
+            } else {
+                ResultSource.Error(AppError.UnknownError)
+            }
+        }
+    }
+}

--- a/registration/src/main/java/com/valify/registration/domain/repository/ImageRepository.kt
+++ b/registration/src/main/java/com/valify/registration/domain/repository/ImageRepository.kt
@@ -1,0 +1,10 @@
+package com.valify.registration.domain.repository
+
+import com.valify.registration.domain.utils.ResultSource
+
+
+interface ImageRepository {
+
+    suspend fun saveCapturedImage(image:String): ResultSource<Boolean>
+
+}

--- a/registration/src/main/java/com/valify/registration/domain/usecases/SaveCapturedImageUseCase.kt
+++ b/registration/src/main/java/com/valify/registration/domain/usecases/SaveCapturedImageUseCase.kt
@@ -1,0 +1,14 @@
+package com.valify.registration.domain.usecases
+
+import android.graphics.Bitmap
+import com.valify.registration.domain.repository.ImageRepository
+import com.valify.registration.domain.utils.ResultSource
+import com.valify.registration.utils.bitmapToBase64
+import javax.inject.Inject
+
+internal class SaveCapturedImageUseCase @Inject constructor(private val repository: ImageRepository) {
+
+    suspend operator fun invoke(image: Bitmap): ResultSource<Boolean> =
+        repository.saveCapturedImage(image.bitmapToBase64())
+
+}

--- a/registration/src/main/java/com/valify/registration/presentation/captureImage/CaptureImageFragment.kt
+++ b/registration/src/main/java/com/valify/registration/presentation/captureImage/CaptureImageFragment.kt
@@ -1,0 +1,180 @@
+package com.valify.registration.presentation.captureImage
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.net.Uri
+import android.os.Bundle
+import android.provider.Settings
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.google.android.material.snackbar.Snackbar
+import com.google.common.util.concurrent.ListenableFuture
+import com.valify.registration.R
+import com.valify.registration.databinding.FragmentCaptureImageBinding
+import com.valify.registration.domain.utils.AppError
+import com.valify.registration.presentation.captureImage.viewmodel.CaptureIntent
+import com.valify.registration.presentation.captureImage.viewmodel.CaptureViewModel
+import com.valify.registration.utils.FaceDetectSmile
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import java.util.concurrent.Executor
+
+@AndroidEntryPoint
+class CaptureImageFragment : Fragment(R.layout.fragment_capture_image) {
+
+    private var _binding: FragmentCaptureImageBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: CaptureViewModel by viewModels()
+    private lateinit var cameraProviderFuture: ListenableFuture<ProcessCameraProvider>
+    private val imageCapture = ImageCapture.Builder().build()
+
+    private val cameraPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted: Boolean ->
+        if (isGranted) {
+            binding.tryToStartCamera()
+        } else {
+            val showRationale = shouldShowRequestPermissionRationale(Manifest.permission.CAMERA)
+            if (!showRationale) {
+                Snackbar.make(binding.root, getString(R.string.please_enable_camera_permission_msg), Snackbar.LENGTH_LONG)
+                    .setAction("Settings") {
+                        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                            data = Uri.fromParts("package", requireContext().packageName, null)
+                        }
+                        startActivity(intent)
+                    }
+                    .show()
+            } else {
+                Toast.makeText(requireContext(), getString(R.string.camera_permission_is_required_msg), Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
+        FragmentCaptureImageBinding.inflate(inflater, container, false).also { _binding = it }.root
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.bindClicks()
+        binding.tryToStartCamera()
+        binding.collectCaptureImageState()
+    }
+
+    private fun trySaveImageCaptured(bitmap: Bitmap) {
+        viewModel.sendIntent(CaptureIntent.SaveCaptureImageIntent(bitmap))
+    }
+
+    private fun FragmentCaptureImageBinding.cameraInit() {
+        cameraProviderFuture = ProcessCameraProvider.getInstance(requireContext())
+        cameraProviderFuture.addListener({
+            val cameraProvider = cameraProviderFuture.get()
+            bindPreview(cameraProvider)
+        }, ContextCompat.getMainExecutor(requireContext()))
+    }
+
+    private fun FragmentCaptureImageBinding.bindPreview(cameraProvider: ProcessCameraProvider) {
+        cameraProvider.unbindAll()
+        val executor = ContextCompat.getMainExecutor(requireContext())
+        val preview: Preview = Preview.Builder()
+            .build()
+
+        val cameraSelector: CameraSelector = CameraSelector.Builder()
+            .requireLensFacing(CameraSelector.LENS_FACING_FRONT)
+            .build()
+
+        preview.surfaceProvider = cameraContainer.getSurfaceProvider()
+        cameraProvider.bindToLifecycle(viewLifecycleOwner, cameraSelector, preview, imageCapture, smileDetection(executor) {
+            captureImage(executor, imageCapture) {
+                trySaveImageCaptured(it)
+            }
+        })
+    }
+
+    private fun FragmentCaptureImageBinding.bindClicks() {
+        permissionCameraButton.setOnClickListener {
+            if (!isGrantedCameraPermission()) {
+                cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+            }
+        }
+    }
+
+    private fun FragmentCaptureImageBinding.tryToStartCamera() {
+        if (isGrantedCameraPermission()) {
+            permissionMsg.visibility = View.GONE
+            permissionCameraButton.visibility = View.GONE
+            cameraContainer.visibility = View.VISIBLE
+            cameraInit()
+        } else {
+            cameraContainer.visibility = View.GONE
+            permissionMsg.visibility = View.VISIBLE
+            permissionCameraButton.visibility = View.VISIBLE
+
+        }
+    }
+
+    private fun FragmentCaptureImageBinding.collectCaptureImageState() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collectLatest { state ->
+                    with(state) {
+                        appFailure?.apply {
+                            if (this !is AppError.ValidateError) {
+                                val message = when (this) {
+                                    is AppError.DatabaseError -> getString(R.string.database_error_msg)
+                                    else -> getString(R.string.something_went_wrong_msg)
+                                }
+                                Snackbar.make(root, message, Snackbar.LENGTH_SHORT).setBackgroundTint(Color.RED).setTextColor(Color.WHITE).show()
+                            }
+                        }
+                        if (success) {
+                            requireActivity().finish()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun captureImage(executor: Executor, imageCapture: ImageCapture, onImageCaptured: (Bitmap) -> Unit) {
+        imageCapture.takePicture(executor, object : ImageCapture.OnImageCapturedCallback() {
+            override fun onCaptureSuccess(image: ImageProxy) {
+                onImageCaptured(image.toBitmap())
+                image.close()
+            }
+        })
+    }
+
+    private fun smileDetection(executor: Executor, onSmileDetect: () -> Unit): ImageAnalysis {
+        return ImageAnalysis.Builder().setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST).build().also {
+            it.setAnalyzer(executor, FaceDetectSmile(onSmileDetect))
+        }
+    }
+
+    private fun isGrantedCameraPermission() =
+        ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED
+
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/registration/src/main/java/com/valify/registration/presentation/captureImage/viewmodel/CaptureIntent.kt
+++ b/registration/src/main/java/com/valify/registration/presentation/captureImage/viewmodel/CaptureIntent.kt
@@ -1,0 +1,9 @@
+package com.valify.registration.presentation.captureImage.viewmodel
+
+import android.graphics.Bitmap
+import androidx.annotation.Keep
+
+@Keep
+sealed class CaptureIntent {
+    data class SaveCaptureImageIntent(val image: Bitmap) : CaptureIntent()
+ }

--- a/registration/src/main/java/com/valify/registration/presentation/captureImage/viewmodel/CaptureState.kt
+++ b/registration/src/main/java/com/valify/registration/presentation/captureImage/viewmodel/CaptureState.kt
@@ -1,0 +1,11 @@
+package com.valify.registration.presentation.captureImage.viewmodel
+
+import androidx.annotation.Keep
+import com.valify.registration.domain.utils.AppError
+
+@Keep
+data class CaptureState(
+    val success: Boolean = false,
+    val appFailure: AppError? = null,
+)
+

--- a/registration/src/main/java/com/valify/registration/presentation/captureImage/viewmodel/CaptureViewModel.kt
+++ b/registration/src/main/java/com/valify/registration/presentation/captureImage/viewmodel/CaptureViewModel.kt
@@ -1,0 +1,61 @@
+package com.valify.registration.presentation.captureImage.viewmodel
+
+import android.graphics.Bitmap
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.valify.registration.domain.usecases.SaveCapturedImageUseCase
+import com.valify.registration.domain.utils.ResultSource
+
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+
+@HiltViewModel
+internal class CaptureViewModel @Inject constructor(
+    private val saveCapturedImageUseCase: SaveCapturedImageUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CaptureState())
+    val uiState = _uiState.asStateFlow()
+    private val _intent = MutableSharedFlow<CaptureIntent>(extraBufferCapacity = 1)
+
+    init {
+        handleIntent()
+    }
+
+    private fun handleIntent() {
+        viewModelScope.launch {
+            _intent.collectLatest {
+                when (it) {
+                    is CaptureIntent.SaveCaptureImageIntent -> handleSaveCaptureImage(it.image)
+                }
+            }
+        }
+    }
+
+    fun sendIntent(intent: CaptureIntent) {
+        _intent.tryEmit(intent)
+    }
+
+    private fun handleSaveCaptureImage(image: Bitmap) {
+        _uiState.update { it.copy(success = false, appFailure = null) }
+        viewModelScope.launch {
+            when (val result = saveCapturedImageUseCase(image)) {
+                is ResultSource.Success -> {
+                    _uiState.update { it.copy(success = result.data, appFailure = null) }
+                }
+
+                is ResultSource.Error -> {
+                    _uiState.update { it.copy(success = false, appFailure = result.exception) }
+                }
+            }
+        }
+    }
+
+}

--- a/registration/src/main/java/com/valify/registration/presentation/registration/RegistrationFormFragment.kt
+++ b/registration/src/main/java/com/valify/registration/presentation/registration/RegistrationFormFragment.kt
@@ -21,6 +21,7 @@ import com.valify.registration.domain.utils.ValidationType
 import com.valify.registration.presentation.registration.viewmodel.RegistrationIntent
 import com.valify.registration.presentation.registration.viewmodel.RegistrationViewModel
 import com.valify.registration.utils.hiddenKeyboard
+import com.valify.registration.utils.navigationSafe
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -100,7 +101,7 @@ class RegistrationFormFragment : Fragment(R.layout.fragment_registration_form) {
 
             "password" -> {
                 passwordInputLayout.error = if (type == ValidationType.Empty) getString(R.string.required_text_field)
-                else getString(R.string.please_enter_valid_phone_error_msg)
+                else getString(R.string.please_enter_valid_password_error_msg)
             }
         }
     }
@@ -127,7 +128,7 @@ class RegistrationFormFragment : Fragment(R.layout.fragment_registration_form) {
                         }
 
                         if (success) {
-                            // Navigate to capture image
+                           navigationSafe(RegistrationFormFragmentDirections.actionRegistrationFormFragmentToCaptureImageFragment())
                         }
                     }
 

--- a/registration/src/main/java/com/valify/registration/utils/FaceDetectSmile.kt
+++ b/registration/src/main/java/com/valify/registration/utils/FaceDetectSmile.kt
@@ -1,0 +1,34 @@
+package com.valify.registration.utils
+
+import androidx.annotation.OptIn
+import androidx.camera.core.ExperimentalGetImage
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.face.FaceDetection
+import com.google.mlkit.vision.face.FaceDetectorOptions
+
+class FaceDetectSmile(private val onSmileDetected: () -> Unit) : ImageAnalysis.Analyzer {
+    @OptIn(ExperimentalGetImage::class)
+    override fun analyze(proxyImage: ImageProxy) {
+        val image = proxyImage.image ?: return
+        val inputImage = InputImage.fromMediaImage(image, proxyImage.imageInfo.rotationDegrees)
+        FaceDetection.getClient(
+            FaceDetectorOptions.Builder()
+                .setPerformanceMode(FaceDetectorOptions.PERFORMANCE_MODE_FAST)
+                .setLandmarkMode(FaceDetectorOptions.LANDMARK_MODE_NONE)
+                .setClassificationMode(FaceDetectorOptions.CLASSIFICATION_MODE_ALL)
+                .build()
+        ).process(inputImage).addOnSuccessListener { faces ->
+            for (face in faces) {
+                val smileProb = face.smilingProbability ?: 0.0f
+                if (smileProb > 0.8f) {
+                    onSmileDetected()
+                }
+            }
+        }.addOnCompleteListener {
+            proxyImage.close()
+
+        }
+    }
+}

--- a/registration/src/main/java/com/valify/registration/utils/ImageUtils.kt
+++ b/registration/src/main/java/com/valify/registration/utils/ImageUtils.kt
@@ -1,0 +1,12 @@
+package com.valify.registration.utils
+
+import android.graphics.Bitmap
+import android.util.Base64
+import java.io.ByteArrayOutputStream
+
+
+fun Bitmap.bitmapToBase64():String {
+    val outputStream  = ByteArrayOutputStream()
+    compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+    return Base64.encodeToString(outputStream.toByteArray(),Base64.DEFAULT)
+}

--- a/registration/src/main/java/com/valify/registration/utils/NavigationExtensions.kt
+++ b/registration/src/main/java/com/valify/registration/utils/NavigationExtensions.kt
@@ -1,0 +1,13 @@
+package com.valify.registration.utils
+
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavDirections
+import androidx.navigation.fragment.NavHostFragment
+
+
+fun Fragment.navigationSafe(navDirections: NavDirections) {
+    val navDestination = NavHostFragment.findNavController(this).currentDestination
+    if (navDestination?.getAction(navDirections.actionId) != null && navDestination.id != navDirections.actionId) NavHostFragment.findNavController(
+        this
+    ).navigate(navDirections)
+}

--- a/registration/src/main/res/layout/fragment_capture_image.xml
+++ b/registration/src/main/res/layout/fragment_capture_image.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+        <androidx.camera.view.PreviewView
+            android:id="@+id/camera_container"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            />
+
+    <TextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/_14sdp"
+        android:gravity="center"
+        android:visibility="gone"
+        android:id="@+id/permission_msg"
+        android:text="@string/camera_permission_msg"
+        android:textColor="@color/black"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/permission_camera_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:insetBottom="1dp"
+        android:visibility="gone"
+        android:insetTop="1dp"
+        app:cornerRadius="45dp"
+        android:text="@string/grant_permission_label"
+        android:layout_marginVertical="@dimen/_14sdp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/permission_msg"
+        />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/registration/src/main/res/navigation/host_navigation.xml
+++ b/registration/src/main/res/navigation/host_navigation.xml
@@ -9,5 +9,16 @@
         android:id="@+id/registrationFormFragment"
         tools:layout="@layout/fragment_registration_form"
         android:name="com.valify.registration.presentation.registration.RegistrationFormFragment"
-        android:label="RegistrationFormFragment" />
+        android:label="RegistrationFormFragment" >
+        <action
+            android:id="@+id/action_registrationFormFragment_to_captureImageFragment"
+            app:destination="@id/captureImageFragment"
+            app:popUpTo="@id/registrationFormFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
+    <fragment
+        android:id="@+id/captureImageFragment"
+        tools:layout="@layout/fragment_capture_image"
+        android:name="com.valify.registration.presentation.captureImage.CaptureImageFragment"
+        android:label="CaptureImageFragment" />
 </navigation>

--- a/registration/src/main/res/values/strings.xml
+++ b/registration/src/main/res/values/strings.xml
@@ -12,4 +12,8 @@
     <string name="password_text_field_label">Password *</string>
     <string name="database_error_msg">We encounter issue connecting to database</string>
     <string name="something_went_wrong_msg">Something went wrong</string>
+    <string name="camera_permission_msg">Please grant the permission to use the camera to use the core functionality of this app.</string>
+    <string name="grant_permission_label">Grant permission</string>
+    <string name="please_enable_camera_permission_msg">Please enable camera permission in settings.</string>
+    <string name="camera_permission_is_required_msg">Camera permission is required</string>
 </resources>


### PR DESCRIPTION
feat: Implement Image Capture with Camera and Base64 Conversion

This commit introduces the functionality to capture images using the camera, detect smiles, and save the captured image as a Base64 string.
It includes the following changes:

-   Added camera permission handling and UI for granting permission.
-   Implemented `CaptureImageFragment` for capturing images with camera.
-   Implemented `CaptureViewModel`, `CaptureState`, and `CaptureIntent` to manage the capture flow and save the image.
-   Implemented `FaceDetectSmile` for detecting smiles using ML Kit.
-   Implemented a navigation from `RegistrationFormFragment` to `CaptureImageFragment`.
-   Implemented `navigationSafe` to handle safe navigation between the fragments.
-   Added `bitmapToBase64` extension for converting `Bitmap` images to Base64 strings.
-   Updated the `strings.xml` file with new strings related to camera permissions.
- Added CameraX dependencies.
- Updated project plugins to add the safe args plugin.